### PR TITLE
[doc] correction of a typographical error

### DIFF
--- a/doc/moveit-tutorial_ja_robot-python_basic.md
+++ b/doc/moveit-tutorial_ja_robot-python_basic.md
@@ -1450,7 +1450,7 @@ if __name__ == '__main__':
 で得られる，`quaternion_from_euler(0, 0, -1.57079)` 関数を用いて取得します．
 
 また，このプログラムに続けて
-以下のようにうに，`pose_target_1`, `pose_target_2`を用いて
+以下のように，`pose_target_1`, `pose_target_2`を用いて
 `group.compute_cartesian_path([pose_target_1, pose_target_2], 0.01, 0.0)`
 として直線補間軌道を計画し，`group.execute( plan )` で実行します．
 

--- a/doc/moveit-tutorial_ja_robot-simulator.md
+++ b/doc/moveit-tutorial_ja_robot-simulator.md
@@ -361,7 +361,7 @@ echo "source ~/catkin_ws/devel/setup.bash" >> ~/.bashrc
 
 ## ソースインストール
 
-apt でインストールできるようにバイナリ／リリースされていないロボットパッケージはワークスペース経由でインストールすることができます．標準では推奨されていな方法ですので十分に注意して実行してください．
+apt でインストールできるようにバイナリ／リリースされていないロボットパッケージはワークスペース経由でインストールすることができます．標準では推奨されていない方法ですので十分に注意して実行してください．
 
 まず，`/tmp/catkin_ws` という名前のワークスペースを作成する手順は次のとおりです．
 
@@ -746,7 +746,7 @@ roslaunch khi_duaro_moveit_config moveit_planning_execution.launch
 
 ```bash
 source ~/catkin_ws/devel/setup.bash
-roslaunch roslaunch mycobot_280_moveit demo.launch
+roslaunch mycobot_280_moveit demo.launch
 ```
 
 他のmyCobot ，例えば myCobot 320 用のシミュレータを立ち上げる場合は次のようにして MoveIt! を起動します．


### PR DESCRIPTION
現時点で見つけたタイポを修正しました。よろしくお願いいたします。

- p.6の2.3 ソースインストール (moveit-tutorial_ja_robot-simulator.md)
推奨されていな方法

- p.34 の3.2.4 myCobot の場合 (moveit-tutorial_ja_robot-python_basic.md)
`roslaunch roslaunch ...`

- p.36の3.2.4 myCobot の場合 (moveit-tutorial_ja_robot-python_basic.md)
以下のようにうに
