### PR TITLE
[doc/index.md] update index.md: add moveit-tutorial_ja_how-to-use-real-mycobot.md to contents

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -13,3 +13,6 @@ Contents
 * [トラブルシューティング](moveit-tutorial_ja_trouble-shooting.md)
 * [クラス・関数リファレンス](moveit-tutorial_ja_reference-class-functions.md)
 * [Python チュートリアル](moveit-tutorial_ja_python.md)
+<$if <$ROS_DISTRO>==melodic|<$ROS_DISTRO>==noetic>
+* [実機の使用法](moveit-tutorial_ja_how-to-use-real-mycobot.md)
+<$endif>


### PR DESCRIPTION
PR/noeticの最新版の資料を確認した時、melodicもnoeticも両方、
`moveit-tutorial_ja_how-to-use-real-mycobot.md`の内容が含まれていませんでした。
その理由は、`index.md`の修正忘れだと考えて、contentsに追加しました。